### PR TITLE
Fixed appending sheets that have names greater than 31 characters error

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -167,7 +167,7 @@ router.post(`/${APP_VERSION}/download`, async function (req, res, next) {
         const ws = xlsxHeader
           ? XLSX.utils.json_to_sheet(gqlRes[k], { header: xlsxHeader })
           : XLSX.utils.json_to_sheet(gqlRes[k])
-        XLSX.utils.book_append_sheet(wb, ws, k)
+        XLSX.utils.book_append_sheet(wb, ws, k.slice(0, 31))
       })
       if (ext === 'tsv' || (ext === 'csv' && colSep != ',')) {
         res.set('Content-Type', 'text/csv')


### PR DESCRIPTION
## Changes

Sliced the JS Object's key to 31 characters to not throw the lib error.

![image](https://github.com/datopian/data-api/assets/57202549/6cf09ce7-4ef0-47d6-9642-173f454e9e87)
